### PR TITLE
Add VimwikiAll2HTML non-interactive html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `VimwikiAll2HTML[!]`
+
+### Changed
+
+- Update documentation
+- Add `vimwiki.allhtml` (bool) to `scripts/pre-commit.sh`.
+
 ## [v1.0.2] - 2022-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following table details the mapping between these commands:
 | CLI Command                             | Ex Commands                                                         |
 |-----------------------------------------|---------------------------------------------------------------------|
 | `vimwiki`                               | `:VimwikiIndex`                                                     |
+| `vimwiki all-html`                      | `:VimwikiIndex \| VimwikiAll2HTML`                                  |
 | `vimwiki check-links`                   | `:VimwikiIndex \| VimwikiCheckLinks`                                |
 | `vimwiki diary`                         | `:VimwikiDiaryIndex`                                                |
 | `vimwiki diary generate-links`          | `:VimwikiDiaryIndex \| VimwikiDiaryGenerateLinks`                   |
@@ -88,6 +89,7 @@ The pre-commit hook relies on the following configuration options:
 | `vimwiki.generatediarylinks` | Generate diary links before commit (bool)      |
 | `vimwiki.generatetaglinks`   | Generate tag links before commit (bool)        |
 | `vimwiki.rebuildtags`        | Rebuild tag metadata before commit (bool)      |
+| `vimwiki.allhtml`            | Convert wiki to HTML before commit (bool)      |
 
 For example, to configure the hook to rebuild tag metadata and generate tag
 links in the `Tags` page before commit, issue:

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -68,6 +68,13 @@ then
 	say_done
 fi
 
+if test "$(git config --bool vimwiki.allhtml || echo false)" = true
+then
+	say 'Converting all wiki pages to HTML...'
+	vimwiki $options all-html || exit
+	say_done
+fi
+
 if test "$(git config --bool vimwiki.generatetaglinks || echo false)" = true
 then
 	page=$(git config vimwiki.taglinkspage || echo index)

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -12,6 +12,7 @@
 # vimwiki.generatediarylinks -- Generate diary links before commit (bool)
 # vimwiki.generatetaglinks -- Generate tag links before commit (bool)
 # vimwiki.rebuildtags -- Rebuild tag metadata before commit (bool)
+# vimwiki.allhtml -- Convert wiki to HTML before commit (bool)
 #
 # To enable this hook, copy or link this file to ".git/hooks/pre-commit".
 
@@ -68,19 +69,19 @@ then
 	say_done
 fi
 
-if test "$(git config --bool vimwiki.allhtml || echo false)" = true
-then
-	say 'Converting all wiki pages to HTML...'
-	vimwiki $options all-html || exit
-	say_done
-fi
-
 if test "$(git config --bool vimwiki.generatetaglinks || echo false)" = true
 then
 	page=$(git config vimwiki.taglinkspage || echo index)
 
 	say 'Generating tag links...'
 	vimwiki $options tags generate-links "$page" || exit
+	say_done
+fi
+
+if test "$(git config --bool vimwiki.allhtml || echo false)" = true
+then
+	say 'Converting all wiki pages to HTML...'
+	vimwiki $options all-html || exit
 	say_done
 fi
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,18 @@ def test_default(mock_index, runner):
     mock_index.assert_called_with()
 
 
+@mock.patch('vimwiki_cli.wiki.Wiki.all_html')
+@pytest.mark.parametrize('args,expected', [
+    ('', False),
+    ('--all', True)
+])
+def test_all_html(mock_all_html, runner, args, expected):
+    result = runner.invoke(cli, 'all-html ' + args)
+    assert result.exit_code == 0
+
+    mock_all_html.assert_called_with(expected)
+
+
 @mock.patch('vimwiki_cli.wiki.Wiki.check_links')
 def test_check_links(mock_check_links, runner):
     result = runner.invoke(cli, 'check-links')

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -105,6 +105,18 @@ def test_diary_generate_links(mock_cmd, wiki):
 
 
 @mock.patch('vimwiki_cli.wiki.LocalCommand')
+@pytest.mark.parametrize('args,expected', [
+    (False, 'silent! VimwikiAll2HTML'),
+    (True, 'silent! VimwikiAll2HTML!')
+])
+def test_all_html(mock_cmd, wiki, args, expected):
+    wiki.all_html(args)
+
+    mock_cmd.assert_called_with(wiki, expected,
+                                interactive=False, quit=True)
+
+
+@mock.patch('vimwiki_cli.wiki.LocalCommand')
 def test_check_links(mock_cmd, wiki):
     wiki.check_links()
 

--- a/vimwiki_cli/__main__.py
+++ b/vimwiki_cli/__main__.py
@@ -82,6 +82,15 @@ def cli(ctx, *args, **kwargs):
 
 
 @cli.command()
+@click.option('--all', is_flag=True,
+              help='Rebuild all files, not just those that are newer.')
+@pass_wiki
+def all_html(wiki, all):
+    """Convert all wiki pages to HTML."""
+    wiki.all_html(all)
+
+
+@cli.command()
 @pass_wiki
 def check_links(wiki):
     """Search files and check reachability of links."""

--- a/vimwiki_cli/wiki.py
+++ b/vimwiki_cli/wiki.py
@@ -112,6 +112,11 @@ class Wiki(object):
         DiaryCommand(self, 'VimwikiDiaryGenerateLinks',
                      interactive=False, write_quit=True).run()
 
+    def all_html(self, all=False):
+        """Convert all wiki pages to HTML."""
+        LocalCommand(self, 'silent! VimwikiAll2HTML' + ('!' if all else ''),
+                     interactive=False, quit=True).run()
+
     def check_links(self):
         """Search files and check reachability of links."""
         LocalCommand(self, 'VimwikiCheckLinks').run()


### PR DESCRIPTION
Closes #5.

`vimwiki all-html [--all]` converts updated wiki pages to html.

`git config vimwiki.allhtml true` non-interactively converts updated wiki pages using the pre-commit hook script provided.