### PR TITLE
Add pre-commit manifest to simplify installing the pre-commit hook (Issue #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '2.7'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: vimwiki-cli
+  name: Vimwiki rebuild tag metadata and generate links
+  description: A pre-commit hook script to execute non-interactive vimwiki commands to rebuild tag metadata and generate links before commit.
+  entry: scripts/pre-commit.sh
+  language: python
+  types: [markdown]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,18 @@
 - id: vimwiki-cli
-  name: Vimwiki rebuild tag metadata and generate links
-  description: A pre-commit hook script to execute non-interactive vimwiki commands to rebuild tag metadata and generate links before commit.
+  name: Vimwiki Command-Line Interface
+  description: |
+    A pre-commit hook script to execute non-interactive vimwiki commands to
+    rebuild tag metadata and generate links before commit. This hook relies on
+    the following configuration options.
+    vimwiki.options -- Extra options to pass to the vimwiki command
+    vimwiki.linkspage -- Page which contains generated links
+    vimwiki.taglinkspage -- Page which contains generated tag links
+    vimwiki.generatelinks -- Generate links before commit (bool)
+    vimwiki.generatediarylinks -- Generate diary links before commit (bool)
+    vimwiki.generatetaglinks -- Generate tag links before commit (bool)
+    vimwiki.rebuildtags -- Rebuild tag metadata before commit (bool)
+    vimwiki.allhtml -- Convert wiki to HTML before commit (bool)
   entry: scripts/pre-commit.sh
-  language: python
-  types: [markdown]
+  language: script
+  require_serial: true
+  types: [text]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `pre-commit` hook `id: vimwiki-cli` to simplify installing `pre-commit.sh`
+  script (
+  [Issue #7](https://github.com/sstallion/vimwiki-cli/issues/7#issue-876664886))
+
+### Changed
+
 ## [v1.1.0] - 2023-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Github Actions workflow `CI` removed python-2.7 and added python-3.11 because
+  `ubuntu-latest` dropped python-2.7 support. Updated `checkout` and
+  `setup-python` actions to latest versions.
+
 ## [v1.1.0] - 2023-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ variables are available to modify default behavior without the need to pass
 global options on the command line:
 
 | Environment Variable   | Global Option    | Description                                       |
-|------------------------|------------------|---------------------------------------------------|
+| ---------------------- | ---------------- | ------------------------------------------------- |
 | `VIMWIKI_EDITOR`       | `--editor`       | Editor to launch, defaults to `$EDITOR` or `vim`. |
 | `VIMWIKI_COUNT`        | `--count`        | Index of wiki to open.                            |
 | `VIMWIKI_SELECT`       | `--select`       | Select wiki from interactive list.                |
@@ -43,7 +43,7 @@ Each CLI command corresponds to one or more Ex commands executed in the editor.
 The following table details the mapping between these commands:
 
 | CLI Command                             | Ex Commands                                                         |
-|-----------------------------------------|---------------------------------------------------------------------|
+| --------------------------------------- | ------------------------------------------------------------------- |
 | `vimwiki`                               | `:VimwikiIndex`                                                     |
 | `vimwiki all-html`                      | `:VimwikiIndex \| VimwikiAll2HTML`                                  |
 | `vimwiki check-links`                   | `:VimwikiIndex \| VimwikiCheckLinks`                                |
@@ -81,7 +81,7 @@ commit.
 The pre-commit hook relies on the following configuration options:
 
 | Configuration Option         | Description                                    |
-|------------------------------|------------------------------------------------|
+| ---------------------------- | ---------------------------------------------- |
 | `vimwiki.options`            | Extra options to pass to the `vimwiki` command |
 | `vimwiki.linkspage`          | Page which contains generated links            |
 | `vimwiki.taglinkspage`       | Page which contains generated tag links        |
@@ -99,7 +99,19 @@ links in the `Tags` page before commit, issue:
     $ git config vimwiki.rebuildtags true
 
 To enable the hook, copy or link [pre-commit.sh][6] to `.git/hooks/pre-commit`
-in the wiki directory.
+in the wiki directory. Alternatively, if [pre-commit][8] is installed, add a
+`pre-commit` configuration file, `.pre-commit-config.yaml` and run
+`pre-commit autoupdate` to enable the latest version of the hook.
+
+```yaml
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/sstallion/vimwiki-cli
+    rev: v1.1.0
+    hooks:
+      - id: vimwiki-cli
+```
 
 ## Contributing
 
@@ -117,3 +129,4 @@ Source code in this repository is licensed under a Simplified BSD License. See
 [5]: https://www.vim.org/
 [6]: https://github.com/sstallion/vimwiki-cli/blob/master/scripts/pre-commit.sh
 [7]: https://github.com/sstallion/vimwiki-cli/blob/master/CONTRIBUTING.md
+[8]: https://pre-commit.com/index


### PR DESCRIPTION
[Pre-commit](https://pre-commit.com/) simplifies installing and using one or more pre-commit hooks. The manifest, `.pre-commit-hooks.yaml` adds the feature. The README explains use.